### PR TITLE
fix zoom/pan glitch on plane photos

### DIFF
--- a/css/60_photos.css
+++ b/css/60_photos.css
@@ -475,11 +475,10 @@ label.streetside-hires {
     transform-origin: 0 0;
 }
 
-.photoviewer .plane-frame > img.plane-photo{
-    width: 100%;
+.photoviewer .plane-frame > img.plane-photo {
+    width: auto;
     height: 100%;
-    object-fit: cover;
-    overflow: hidden;
+    transform-origin: 0 0;
 }
 
 /* photo-controls (step forward, back, rotate) */

--- a/modules/services/plane_photo.js
+++ b/modules/services/plane_photo.js
@@ -87,14 +87,13 @@ export default {
 
   selectPhoto: function (data, keepOrientation) {
     dispatch.call('viewerChanged');
+
     loadImage(_photo, '');
     loadImage(_photo, data.image_path)
       .then(() => {
-        if (!keepOrientation) {
-          imgZoom = zoomBeahvior();
-          _wrapper.call(imgZoom);
-          _wrapper.call(imgZoom.transform, d3_zoomIdentity.translate(-_widthOverflow / 2, 0));
-        }
+        imgZoom = zoomBeahvior();
+        _wrapper.call(imgZoom);
+        _wrapper.call(imgZoom.transform, d3_zoomIdentity.translate(-_widthOverflow / 2, 0));
       });
     return this;
   },


### PR DESCRIPTION
This should fix the issue of glitching out margins and zoom/pan behaviour of non-360° panoramax photos:

* When changing to a different photo, it can be the case that the new photo has a different aspect ratio: the zoom behaviour needs to be updated.
* `transform-origin: 0 0;` seems to be needed in the CSS to make the zoom/panning to work properly
* Also, the `keepOrientation` flag does not make too much sense for plane photos (even keeping the previously shown photo's zoom is also not typically desired) -> we can just ignore this flag for non 360° photos